### PR TITLE
feat: add uvx/pip support with PEP 621 pyproject.toml

### DIFF
--- a/app.py
+++ b/app.py
@@ -639,7 +639,8 @@ async def k8s_get_cronjobs(context: str, namespace: Optional[str] = None,
 # ENTRY POINT
 # ========================================================================
 
-if __name__ == "__main__":
+def main():
+    """Entry point for the MCP server."""
     # Set kubeconfig directory from environment variable if provided
     kubeconfig_dir = os.environ.get("KUBECONFIG_DIR")
     if kubeconfig_dir:
@@ -652,3 +653,7 @@ if __name__ == "__main__":
 
     print("Starting Kubernetes MCP server with stdio transport...")
     mcp.run(transport="stdio")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,18 +1,27 @@
-[tool.uv]
+[project]
 name = "k8s-multicluster-mcp"
 version = "2.0.0"
 description = "An MCP (Model Context Protocol) server for managing multiple Kubernetes clusters. Provides 60+ tools for cluster operations, monitoring, RBAC, storage, networking, and more."
-authors = ["razvanmacovei"]
+authors = [{name = "razvanmacovei"}]
+readme = "README.md"
+license = {text = "MIT"}
+requires-python = ">=3.11"
+dependencies = [
+    "fastmcp",
+    "kubernetes>=28.1.0",
+    "httpx",
+    "pydantic",
+    "pyyaml",
+    "jsonpatch",
+]
 
-[tool.uv.dependencies]
-python = "^3.11"
-fastmcp = "*"
-kubernetes = ">=28.1.0"
-httpx = "*"
-pydantic = "*"
-pyyaml = "*"
-jsonpatch = "*"
+[project.scripts]
+k8s-multicluster-mcp = "app:main"
 
 [build-system]
-requires = ["uv-core>=1.0.0"]
-build-backend = "uv.core.masonry.api"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src"]
+include = ["app.py"]


### PR DESCRIPTION
Closes #20

## Changes

- Convert `pyproject.toml` from `[tool.uv]` to standard `[project]` (PEP 621)
- Add `[project.scripts]` entry point for CLI installation
- Extract `main()` function from `__main__` block in `app.py`
- Use `hatchling` as build backend

## Testing

```bash
# Install from source
pip install -e .

# Run
k8s-multicluster-mcp

# Or via uvx (after PyPI publish)
uvx k8s-multicluster-mcp
```