### PR TITLE
feat: add uvx/pip install support via pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,4 +24,6 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src"]
-include = ["app.py"]
+
+[tool.hatch.build.targets.wheel.force-include]
+"app.py" = "app.py"


### PR DESCRIPTION
Adds PEP 621 `pyproject.toml` with hatchling build backend, enabling installation via `uvx` or `pip`.

## Changes
- `pyproject.toml` with entry point `k8s-multicluster-mcp = "app:main"`
- `force-include` for `app.py` in wheel build
- All deps from `requirements.txt` in `[project.dependencies]`

## Usage
```bash
uvx --from "git+https://github.com/razvanmacovei/k8s-multicluster-mcp" k8s-multicluster-mcp
```

Tested: server starts and responds to MCP protocol correctly via uvx.